### PR TITLE
new context impl - fixes #20

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -42,7 +42,10 @@ impl<'names> Context<'names> {
 
     #[inline]
     #[must_use]
-    pub fn with_symbols(mut self, symbols: HashMap<&'names str, Symbol>) -> Self {
+    pub fn with_symbols(
+        mut self,
+        symbols: HashMap<&'names str, Symbol>,
+    ) -> Self {
         self.symbols = symbols;
         self
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,24 +3,33 @@ use std::collections::{HashMap, HashSet};
 /* Crate imports */
 use crate::token::Function;
 
+#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
+pub enum Symbol {
+    Variable(f64),
+    Function(Function),
+}
+
+impl From<f64> for Symbol {
+    #[inline]
+    fn from(value: f64) -> Self {
+        Self::Variable(value)
+    }
+}
+
+impl From<Function> for Symbol {
+    #[inline]
+    fn from(value: Function) -> Self {
+        Self::Function(value)
+    }
+}
+
 #[derive(Debug, Default, PartialEq)]
 pub struct Context<'names> {
-    vars: HashMap<&'names str, f64>,
-    funcs: HashMap<&'names str, Function>,
+    symbols: HashMap<&'names str, Symbol>,
     expected_vars: Option<HashSet<&'names str>>,
 }
 
 impl<'names> Context<'names> {
-    #[inline]
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            vars: HashMap::new(),
-            funcs: HashMap::new(),
-            expected_vars: None,
-        }
-    }
-
     #[inline]
     #[must_use]
     pub fn with_expected_vars(
@@ -32,13 +41,20 @@ impl<'names> Context<'names> {
     }
 
     #[inline]
+    #[must_use]
+    pub fn with_symbols(mut self, symbols: HashMap<&'names str, Symbol>) -> Self {
+        self.symbols = symbols;
+        self
+    }
+
+    #[inline]
     pub fn add_var<T: Into<f64>>(&mut self, name: &'names str, value: T) {
-        self.vars.insert(name, value.into());
+        self.symbols.insert(name, value.into().into());
     }
 
     #[inline]
     pub fn add_func(&mut self, name: &'names str, func: Function) {
-        self.funcs.insert(name, func);
+        self.symbols.insert(name, func.into());
     }
 
     #[inline]
@@ -48,14 +64,8 @@ impl<'names> Context<'names> {
 
     #[inline]
     #[must_use]
-    pub fn get_var(&self, name: &str) -> Option<&f64> {
-        self.vars.get(name)
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn get_func(&self, name: &str) -> Option<&Function> {
-        self.funcs.get(name)
+    pub fn get(&self, name: &str) -> Option<&Symbol> {
+        self.symbols.get(name)
     }
 
     #[inline]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::std_instead_of_core)]
 /* Built-in imports */
 use core::str;
-use std::collections::HashSet;
+use std::{collections::HashSet, convert::Into};
 /* Crate imports */
 #[cfg(feature = "compile-time-optimizations")]
 use crate::element::Simplify;
@@ -170,12 +170,9 @@ impl<'input, 'ctx> ParserImpl<'input, 'ctx> {
         // else defaults to variable
         let ident = self
             .ctx
-            .get_var(name)
-            .map(|&value| Identifier::Constant(value))
-            .or_else(|| {
-                self.ctx.get_func(name).copied().map(Identifier::Function)
-            })
-            .unwrap_or_else(|| Identifier::from_str(name));
+            .get(name)
+            .copied()
+            .map_or_else(|| Identifier::from_str(name), Into::into);
 
         let el = match ident {
             Identifier::Constant(val) => Element::Number(val),

--- a/src/tests/thread_safety.rs
+++ b/src/tests/thread_safety.rs
@@ -1,6 +1,6 @@
 /* Crate imports */
 use crate::{
-    context::Context,
+    context::{Context, Symbol},
     element::{BinOp, Element, FunctionCall, UnOp},
     parser::{ErrorKind, ParseError, Parser},
     token::{Function, Identifier, Operator},
@@ -13,6 +13,7 @@ const fn is_sized_send_sync_unpin<T: Sized + Send + Sync + Unpin>() {}
 const fn test_thread_safety() {
     // context module
     is_sized_send_sync_unpin::<Context>();
+    is_sized_send_sync_unpin::<Symbol>();
     // element module
     is_sized_send_sync_unpin::<BinOp<'_>>();
     is_sized_send_sync_unpin::<Element<'_>>();

--- a/src/token/identifier.rs
+++ b/src/token/identifier.rs
@@ -1,7 +1,7 @@
 /* Built-in imports */
 use core::f64;
 /* Crate imports */
-use crate::{token::Function, utils::built_in_functions};
+use crate::{context::Symbol, token::Function, utils::built_in_functions};
 
 #[derive(Debug, PartialEq, PartialOrd)]
 pub enum Identifier<'a> {
@@ -73,5 +73,14 @@ where
 impl From<Function> for Identifier<'_> {
     fn from(value: Function) -> Self {
         Identifier::Function(value)
+    }
+}
+
+impl From<Symbol> for Identifier<'_> {
+    fn from(symbol: Symbol) -> Self {
+        match symbol {
+            Symbol::Variable(value) => Identifier::Constant(value),
+            Symbol::Function(value) => Identifier::Function(value),
+        }
     }
 }


### PR DESCRIPTION
fixes #20
From now on, only the last set of variables or functions is used, and therefore there are no more name conflicts.